### PR TITLE
Use [style*=] to match for display: none

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@
   }
 
   function elementIsHidden(element) {
-    return element.closest('[aria-hidden="true"], [hidden], [style="display: none"]') != null
+    return element.closest('[aria-hidden="true"], [hidden], [style*="display: none"]') != null
   }
 
   function isText(value) {


### PR DESCRIPTION
Use `*=` instead of `=` to detect a `display: none` property anywhere in the `style` attribute.

Many existing ERB templates use `style="display: none;"` and those are currently not being detected as hidden because of the trailing `;`.

This approach could have some false positives if an invalid value was used like `style="foodisplay: none"`  or `style="display: nonebar"` but that seems like an unlikely scenario.