### PR TITLE
Fix eslint error on var redeclaration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,12 @@
-{ "extends": "eslint:recommended",
+{
+  "extends": "eslint:recommended",
   "env": {
     "browser": true,
     "amd": true
   },
+  "plugins": [
+    "mysticatea"
+  ],
   "rules": {
     "eqeqeq": ["error", "smart"],
     "no-eval": "error",
@@ -10,6 +14,8 @@
     "no-implicit-globals": "error",
     "no-trailing-spaces": "error",
     "no-unused-expressions": "error",
-    "semi": ["error", "never"]
+    "semi": ["error", "never"],
+    "mysticatea/block-scoped-var": "error",
+    "no-redeclare": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/github/accessibilityjs#readme",
   "devDependencies": {
-    "eslint": "^3.19.0"
+    "eslint": "^3.19.0",
+    "eslint-plugin-mysticatea": "^4.2.2"
   }
 }


### PR DESCRIPTION
```
  19:14  error  'i' is already defined  no-redeclare
  32:14  error  'i' is already defined  no-redeclare
  40:14  error  'i' is already defined  no-redeclare
  51:14  error  'i' is already defined  no-redeclare

✖ 4 problems (4 errors, 0 warnings)
```

This adds https://github.com/mysticatea/eslint-plugin/blob/master/docs/rules/block-scoped-var.md to avoid these errors but still catches cases like:

```
var a = 1
var a = 2
```

cc @mislav Do you mind taking a look at this? :eyes: