### PR TITLE
Fix classList iteration

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,9 +188,10 @@
     var componenets = [element.nodeName.toLowerCase()]
     if (element.id) componenets.push('#' + element.id)
     if (element.classList) {
-      element.classList.forEach(function(name) {
+      for (var i = 0; i < element.classList.length; i++) {
+        var name = element.classList[i]
         if (name.match(/^js-/)) componenets.push('.' + name)
-      })
+      }
     }
 
     return componenets.join('')


### PR DESCRIPTION
[DOMTokenList](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList) is not Iterable in Edge, and does not have a `forEach` method, so iterate through the class names with a for loop.

/cc @github/web-systems 